### PR TITLE
Remove python 2 backwards compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 pywin32
-six
 winshell>=0.6

--- a/src/casement/__main__.py
+++ b/src/casement/__main__.py
@@ -1,7 +1,5 @@
 """Enables support for calling the casement cli using `python -m casement`"""
 
-from __future__ import absolute_import
-
 import sys
 
 import casement.cli  # deptry: ignore[DEP003]

--- a/src/casement/env_var.py
+++ b/src/casement/env_var.py
@@ -1,13 +1,13 @@
 import logging
 import os
+import winreg
+from collections.abc import MutableMapping
 from contextlib import contextmanager
 
 import win32api
 import win32con
 import win32file
 import win32gui
-from six.moves import winreg
-from six.moves.collections_abc import MutableMapping
 
 from .registry import REG_LOCATIONS, RegKey
 

--- a/src/casement/registry.py
+++ b/src/casement/registry.py
@@ -4,8 +4,7 @@ Each node in the tree is called a key.
 Each key can contain both subkeys and data entries called values.
 """
 
-import six
-from six.moves import winreg
+import winreg
 
 
 def _generate_key_map():
@@ -84,7 +83,7 @@ class RegKey(object):
             key, sub_key = key.split('\\', 1)
 
         # Convert key strings into winreg keys
-        if isinstance(key, six.string_types):
+        if isinstance(key, str):
             key = key.upper()
             key = key_map[key]
 
@@ -256,7 +255,7 @@ class RegEntry(object):
     def set(self, value, value_type=None):
         key = self.key._key(write=True, create=True)
 
-        if isinstance(value_type, six.string_types):
+        if isinstance(value_type, str):
             value_type = getattr(winreg, value_type)
 
         winreg.SetValueEx(key, self.name, 0, value_type, value)

--- a/src/casement/shortcut.py
+++ b/src/casement/shortcut.py
@@ -67,7 +67,6 @@ import sys
 import tempfile
 from argparse import ArgumentParser
 
-import six
 import win32com.client
 import winshell
 
@@ -303,7 +302,7 @@ class Shortcut(object):
         description = description[:259]
 
         # If args is a list, convert it to a string using subprocess
-        if not isinstance(args, six.string_types):
+        if not isinstance(args, str):
             args = subprocess.list2cmdline(args)
 
         kwargs = {

--- a/tests/test_env_var.py
+++ b/tests/test_env_var.py
@@ -14,8 +14,6 @@ Here are the Environment variables that are modified when write testing is enabl
 Note: See test_registry.py to see how testing registry keys/entries are handled.
 """
 
-from __future__ import absolute_import
-
 import os
 
 import pytest

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -14,6 +14,8 @@ Here are the registry keys that are modified when write testing is enabled.
 Note: See test_env_var.py to see how testing Environment variables are handled.
 """
 
+import winreg
+
 # TODO: Look into using a custom testing registry hive to handle all testing
 # without the need for the host to actually have these registry keys. We should
 # only enable testing of registry modifications once this is resolved.
@@ -21,8 +23,6 @@ Note: See test_env_var.py to see how testing Environment variables are handled.
 from contextlib import contextmanager
 
 import pytest
-import six
-from six.moves import winreg
 
 from casement.registry import REG_LOCATIONS, RegKey
 
@@ -144,13 +144,13 @@ def test_entry():
     # String data type
     entry = reg.entry('PreviewTitle')
     assert entry.type() == winreg.REG_SZ
-    assert isinstance(entry.value(), six.string_types)
+    assert isinstance(entry.value(), str)
     assert entry.value() == 'prop:System.ItemNameDisplay;System.ItemTypeText'
 
     # Expanding string data type
     entry = reg.entry('FriendlyTypeName')
     assert entry.type() == winreg.REG_EXPAND_SZ
-    assert isinstance(entry.value(), six.string_types)
+    assert isinstance(entry.value(), str)
 
 
 def test_sam():

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -18,8 +18,6 @@ Note: See test_env_var.py to see how testing Environment variables are handled.
 # without the need for the host to actually have these registry keys. We should
 # only enable testing of registry modifications once this is resolved.
 # Ie don't running casement tests should not modify the host registry.
-from __future__ import absolute_import
-
 from contextlib import contextmanager
 
 import pytest


### PR DESCRIPTION
Remove legacy uses of `__future__` and six.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [ ] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [ ] Bugfix (change that fixes an issue)
- [x] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)